### PR TITLE
Only source lcg-view setup once, fix integration check

### DIFF
--- a/init_fcc_stack.sh
+++ b/init_fcc_stack.sh
@@ -38,7 +38,12 @@ if [[ "$unamestr" == 'Linux' ]]; then
         source /afs/cern.ch/lhcb/software/releases/LBSCRIPTS/LBSCRIPTS_v8r5p7/InstallArea/scripts/LbLogin.sh --cmtconfig $BINARY_TAG
         # The LbLogin sets VERBOSE to 1 which increases the compilation output. If you want details set this to 1 by hand.
         export VERBOSE=
-        source $LCGPATH/setup.sh
+        # Only source the lcg setup script if paths are not already set
+        # (necessary because of incompatible python install in view)
+        case ":$LD_LIBRARY_PATH:" in
+            *":$LCGPATH/lib64:"*) :;;       # Path is present do nothing
+            *) source $LCGPATH/setup.sh;;   # otherwise setup
+        esac
         # This path is used below to select software versions
         export FCCSWPATH=/afs/cern.ch/exp/fcc/sw/0.7
         echo "Software taken from $FCCSWPATH and LCG_83"

--- a/test_master.sh
+++ b/test_master.sh
@@ -79,7 +79,7 @@ echo "Test fcc-physics-pythia8 -> heppy"
 cd fcc-physics
 ./install/bin/fcc-pythia8-generate ./pythia8/ee_ZH_Zmumu_Hbb.txt
 rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
-mv ee_ZH_Zmumu_Hbb.root ../heppy/test/zh_zmumu_hbb.root
+mv ee_ZH_Zmumu_Hbb.root ../heppy/test/.
 cd ../heppy/test
 heppy_loop.py Trash analysis_ee_ZH_cfg.py -f
 rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi


### PR DESCRIPTION
- Fix:  make sure the `LD_LIBRARY_PATH` does not get polluted by using `init_fcc_master.sh` twice [0]
- Fix: Change input file name for heppy in `test_master.sh` according to recent change in heppy.

[0]: Before this fix, sourcing the script twice led to the `LD_LIBRARY_PATH` being prepended with the lcg-view library paths, while we check in the script whether some path is already in there. This causes problems due to the old Pythia8 version being installed in the view. Now we only source the setup script if the lib64 directory was not already added to the `LD_LIBRARY_PATH`.
