### PR TITLE
Parallel tests for fccsw

### DIFF
--- a/builds/fccsw-build.cmake
+++ b/builds/fccsw-build.cmake
@@ -52,8 +52,12 @@ endif()
 set(CTEST_BUILD_COMMAND "make -j${ncpu}")
 
 
-set(ENV{CTEST_PARALLEL_LEVEL} ${ncpu})
+# not a ctest variable, but used in custom cmake macro
+set(CTEST_TEST_PARALLEL_LEVEL ${ncpu})
+
 set(CTEST_TEST_LOAD ${ncpu})
+
+
 
 #---CDash settings----------------------------------------------------------
 set(CTEST_PROJECT_NAME "FCC")

--- a/builds/fccsw-build.sh
+++ b/builds/fccsw-build.sh
@@ -15,4 +15,4 @@ env | sort
 make purge
 
 #---Run build-------------------------------------------------------------------------------
-ctest -V -S $WORKSPACE/fcc-spi/builds/fccsw-build.cmake --test-load 4
+ctest -V -S $WORKSPACE/fcc-spi/builds/fccsw-build.cmake


### PR DESCRIPTION
Now we should be able to run the tests in parallel. I find it pretty hard to change anything  here - for example I was pretty confused that CTEST_TEST_PARALLEL_LEVEL isn't actually used by ctest, but just indirectly in some macro. @JavierCVilla do you think it makes sense to move some of this configuration directly to the repository?