### PR TITLE
Add configuration template to chain installations

### DIFF
--- a/config/upstreams.tpl
+++ b/config/upstreams.tpl
@@ -1,0 +1,3 @@
+upstreams:
+    fcc-externals:
+        install_tree: {{EXTERNALS_PATH}}


### PR DESCRIPTION
This configuration template file will allow to chain spack installations from cvmfs.